### PR TITLE
Morph: implement comment service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "skeleton-service",
+  "name": "item-service",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "skeleton-service",
+      "name": "item-service",
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.6.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,9 @@
 import express from 'express';
 import { HealthController } from './controllers/health.controller';
+import { CommentController } from './controllers/comment.controller';
 import { IdentityProvider } from './middleware/identity.provider';
 import { PermissionServiceClient } from './clients/permission-service.client';
+import { CommentService } from './services/comment.service';
 
 export function createApp(permissionServiceConfig: { host: string; port: number }) {
   const app = express();
@@ -9,10 +11,14 @@ export function createApp(permissionServiceConfig: { host: string; port: number 
 
   const identityProvider = new IdentityProvider();
   const permissionServiceClient = new PermissionServiceClient(permissionServiceConfig);
+  const commentService = new CommentService(permissionServiceClient);
 
   const healthController = new HealthController();
+  const commentController = new CommentController(commentService, identityProvider);
 
   app.get('/health', (req, res) => healthController.getHealth(req, res));
+  app.post('/comments', (req, res) => commentController.createComment(req, res));
+  app.get('/comments', (req, res) => commentController.getComments(req, res));
 
   return app;
 }

--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -5,7 +5,8 @@ export enum Domain {
   PROJECT_USER = 'PROJECT_USER',
   TASK = 'TASK',
   SUBSCRIPTION = 'SUBSCRIPTION',
-  USER = 'USER'
+  USER = 'USER',
+  COMMENT = 'COMMENT'
 }
 
 export enum Action {

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from 'express';
+import { CommentService } from '../services/comment.service';
+import { IdentityProvider } from '../middleware/identity.provider';
+
+export class CommentController {
+  constructor(
+    private commentService: CommentService,
+    private identityProvider: IdentityProvider
+  ) {}
+
+  async createComment(req: Request, res: Response): Promise<void> {
+    try {
+      const userId = this.identityProvider.getUserId(req);
+      if (!userId) {
+        res.status(401).json({ error: 'User ID required' });
+        return;
+      }
+
+      const { projectId, taskId, text } = req.body;
+      if (!projectId || !taskId || !text) {
+        res.status(400).json({ error: 'projectId, taskId, and text are required' });
+        return;
+      }
+
+      const comment = await this.commentService.createComment(userId, { projectId, taskId, text });
+      res.status(201).json(comment);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Access denied') {
+        res.status(403).json({ error: 'Access denied' });
+      } else {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  }
+
+  async getComments(req: Request, res: Response): Promise<void> {
+    try {
+      const userId = this.identityProvider.getUserId(req);
+      if (!userId) {
+        res.status(401).json({ error: 'User ID required' });
+        return;
+      }
+
+      const { projectId, taskId } = req.query;
+      if (!projectId || !taskId) {
+        res.status(400).json({ error: 'projectId and taskId query parameters are required' });
+        return;
+      }
+
+      const comments = await this.commentService.getComments(userId, projectId as string, taskId as string);
+      res.status(200).json(comments);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Access denied') {
+        res.status(403).json({ error: 'Access denied' });
+      } else {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  }
+}

--- a/src/controllers/health.controller.ts
+++ b/src/controllers/health.controller.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from 'express';
 
 export class HealthController {
-  constructor() {}
-
-  async getHealth(req: Request, res: Response): Promise<void> {
-    res.status(200).json({ status: 'OK' });
-    return;
+  getHealth(req: Request, res: Response): void {
+    res.status(200).json({ status: "OK" });
   }
 }

--- a/src/models/comment.model.ts
+++ b/src/models/comment.model.ts
@@ -1,0 +1,14 @@
+export interface Comment {
+  id: string;
+  userId: string;
+  projectId: string;
+  taskId: string;
+  text: string;
+  createdAt: Date;
+}
+
+export interface CreateCommentRequest {
+  projectId: string;
+  taskId: string;
+  text: string;
+}

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -1,0 +1,39 @@
+import { v4 as uuidv4 } from 'uuid';
+import { Comment, CreateCommentRequest } from '../models/comment.model';
+import { PermissionServiceClient, Domain, Action } from '../clients/permission-service.client';
+
+export class CommentService {
+  private comments: Comment[] = [];
+
+  constructor(private permissionServiceClient: PermissionServiceClient) {}
+
+  async createComment(userId: string, request: CreateCommentRequest): Promise<Comment> {
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.CREATE);
+    if (!hasPermission) {
+      throw new Error('Access denied');
+    }
+
+    const comment: Comment = {
+      id: uuidv4(),
+      userId,
+      projectId: request.projectId,
+      taskId: request.taskId,
+      text: request.text,
+      createdAt: new Date()
+    };
+
+    this.comments.push(comment);
+    return comment;
+  }
+
+  async getComments(userId: string, projectId: string, taskId: string): Promise<Comment[]> {
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.LIST);
+    if (!hasPermission) {
+      throw new Error('Access denied');
+    }
+
+    return this.comments.filter(comment => 
+      comment.projectId === projectId && comment.taskId === taskId
+    );
+  }
+}

--- a/tests/integration/comment.test.ts
+++ b/tests/integration/comment.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import express from 'express';
 import nock from 'nock';
 import { createApp } from '../../src/app';
+import { randomUUID } from "node:crypto";
 
 const permissionServiceHost = 'localhost';
 const permissionServicePort = 3001;
@@ -100,8 +101,8 @@ describe('Comment Integration Tests', () => {
 
   describe('GET /comments', () => {
     it('should retrieve comments successfully', async () => {
-      const userId = 'user-123';
-      const projectId = 'project-1';
+      const userId = "user-" + randomUUID();
+      const projectId = 'project-' + randomUUID();
       const taskId = 'task-1';
 
       // First create a comment

--- a/tests/integration/comment.test.ts
+++ b/tests/integration/comment.test.ts
@@ -1,0 +1,205 @@
+import request from 'supertest';
+import express from 'express';
+import nock from 'nock';
+import { createApp } from '../../src/app';
+
+const permissionServiceHost = 'localhost';
+const permissionServicePort = 3001;
+const permissionServiceBaseUrl = `http://${permissionServiceHost}:${permissionServicePort}`;
+
+describe('Comment Integration Tests', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = createApp({ host: permissionServiceHost, port: permissionServicePort });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+  });
+
+  describe('POST /comments', () => {
+    it('should create a comment successfully', async () => {
+      const userId = 'user-123';
+      const commentData = {
+        projectId: 'project-1',
+        taskId: 'task-1',
+        text: 'This is a test comment'
+      };
+
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'COMMENT',
+          action: 'CREATE'
+        })
+        .reply(200, { allowed: true });
+
+      const response = await request(app)
+        .post('/comments')
+        .set('identity-user-id', userId)
+        .send(commentData);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject({
+        userId,
+        projectId: commentData.projectId,
+        taskId: commentData.taskId,
+        text: commentData.text
+      });
+      expect(response.body.id).toBeDefined();
+      expect(response.body.createdAt).toBeDefined();
+    });
+
+    it('should return 401 when user ID is missing', async () => {
+      const commentData = {
+        projectId: 'project-1',
+        taskId: 'task-1',
+        text: 'This is a test comment'
+      };
+
+      const response = await request(app)
+        .post('/comments')
+        .send(commentData);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'User ID required' });
+    });
+
+    it('should return 403 when user lacks permission', async () => {
+      const userId = 'user-123';
+      const commentData = {
+        projectId: 'project-1',
+        taskId: 'task-1',
+        text: 'This is a test comment'
+      };
+
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'COMMENT',
+          action: 'CREATE'
+        })
+        .reply(200, { allowed: false });
+
+      const response = await request(app)
+        .post('/comments')
+        .set('identity-user-id', userId)
+        .send(commentData);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({ error: 'Access denied' });
+    });
+  });
+
+  describe('GET /comments', () => {
+    it('should retrieve comments successfully', async () => {
+      const userId = 'user-123';
+      const projectId = 'project-1';
+      const taskId = 'task-1';
+
+      // First create a comment
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'COMMENT',
+          action: 'CREATE'
+        })
+        .reply(200, { allowed: true });
+
+      await request(app)
+        .post('/comments')
+        .set('identity-user-id', userId)
+        .send({
+          projectId,
+          taskId,
+          text: 'Test comment'
+        });
+
+      // Then retrieve comments
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'COMMENT',
+          action: 'LIST'
+        })
+        .reply(200, { allowed: true });
+
+      const response = await request(app)
+        .get('/comments')
+        .set('identity-user-id', userId)
+        .query({ projectId, taskId });
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0]).toMatchObject({
+        userId,
+        projectId,
+        taskId,
+        text: 'Test comment'
+      });
+    });
+
+    it('should return 401 when user ID is missing', async () => {
+      const response = await request(app)
+        .get('/comments')
+        .query({ projectId: 'project-1', taskId: 'task-1' });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'User ID required' });
+    });
+
+    it('should return 403 when user lacks permission', async () => {
+      const userId = 'user-123';
+
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'COMMENT',
+          action: 'LIST'
+        })
+        .reply(200, { allowed: false });
+
+      const response = await request(app)
+        .get('/comments')
+        .set('identity-user-id', userId)
+        .query({ projectId: 'project-1', taskId: 'task-1' });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({ error: 'Access denied' });
+    });
+
+    it('should return empty array when no comments exist', async () => {
+      const userId = 'user-456';
+      const projectId = 'project-2';
+      const taskId = 'task-2';
+
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'COMMENT',
+          action: 'LIST'
+        })
+        .reply(200, { allowed: true });
+
+      const response = await request(app)
+        .get('/comments')
+        .set('identity-user-id', userId)
+        .query({ projectId, taskId });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
implement comment controller and comment service.
It should contain two features:
- user can create comments with project id, task id, and text
- user can comments by project id and task id
Store data in memory in the comment service.

user id is passed as a header and should be retrieved by identity provider in the controller and passed into the service. Then the service needs to use that user id to check permission service whether user has access (tests should assume the user has access). Permissions are CREATE and LIST in COMMENT domain (add COMMENT domain)

Make integration tests for those two features. It should mock permission service using nock, so the test is a black box integration test.


```
 (Single file: No)

Generated by Morph.