### PR TITLE
Morph: Permission migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,18 +34,24 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission: subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, domain: Domain, action: Action, tenantId?: string): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission: subjectId=${subjectId}, domain=${domain}, action=${action}, tenantId=${tenantId}`);
     try {
+      const params: any = {
+        subjectId,
+        domain,
+        action
+      };
+      
+      if (tenantId) {
+        params.tenantId = tenantId;
+      }
+
+      const endpoint = tenantId ? '/permissions/v2/check' : '/permissions/check';
+      
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
-        {
-          params: {
-            subjectId,
-            domain,
-            action
-          }
-        }
+        `${this.baseUrl}${endpoint}`,
+        { params }
       );
       console.log(`[PermissionServiceClient] Permission check response: allowed=${response.data.allowed}`);
       return response.data.allowed;

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted user ID from headers: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenant ID from headers: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -7,10 +7,10 @@ export class CommentService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async createComment(userId: string, request: CreateCommentRequest): Promise<Comment> {
-    console.log(`createComment called with userId=${userId}, projectId=${request.projectId}, taskId=${request.taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.CREATE);
-    console.log(`Permission check for CREATE comment: userId=${userId}, result=${hasPermission}`);
+  async createComment(userId: string, request: CreateCommentRequest, tenantId?: string): Promise<Comment> {
+    console.log(`createComment called with userId=${userId}, projectId=${request.projectId}, taskId=${request.taskId}, tenantId=${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.CREATE, tenantId);
+    console.log(`Permission check for CREATE comment: userId=${userId}, tenantId=${tenantId}, result=${hasPermission}`);
     if (!hasPermission) {
       console.error(`Access denied for userId=${userId} on create comment`);
       throw new Error('Access denied');
@@ -30,10 +30,10 @@ export class CommentService {
     return comment;
   }
 
-  async getComments(userId: string, projectId: string, taskId: string): Promise<Comment[]> {
-    console.log(`getComments called with userId=${userId}, projectId=${projectId}, taskId=${taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.LIST);
-    console.log(`Permission check for LIST comment: userId=${userId}, result=${hasPermission}`);
+  async getComments(userId: string, projectId: string, taskId: string, tenantId?: string): Promise<Comment[]> {
+    console.log(`getComments called with userId=${userId}, projectId=${projectId}, taskId=${taskId}, tenantId=${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.LIST, tenantId);
+    console.log(`Permission check for LIST comment: userId=${userId}, tenantId=${tenantId}, result=${hasPermission}`);
     if (!hasPermission) {
       console.error(`Access denied for userId=${userId} on list comments`);
       throw new Error('Access denied');


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Single file: No)

Generated by Morph.