### PR TITLE
Morph: migrate to permission service

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,15 +34,16 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
     console.log(`[PermissionServiceClient] Checking permission:
-      subjectId=${subjectId}, domain=${domain}, action=${action}`);
+      subjectId=${subjectId}, tenantId=${tenantId}, domain=${domain}, action=${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }
@@ -52,7 +53,6 @@ export class PermissionServiceClient {
       return response.data.allowed;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        // Handle specific error cases if needed
         console.error(`[PermissionServiceClient] Permission check failed: ${error.message}`);
       } else {
         console.error(`[PermissionServiceClient] Unexpected error during permission check: ${error}`);

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -11,10 +11,11 @@ export class CommentController {
   async createComment(req: Request, res: Response): Promise<void> {
     try {
       const userId = this.identityProvider.getUserId(req);
-      console.log(`[CommentController] createComment called by userId: ${userId}`);
-      if (!userId) {
-        console.warn('[CommentController] User ID missing in createComment');
-        res.status(401).json({ error: 'User ID required' });
+      const tenantId = this.identityProvider.getTenantId(req);
+      console.log(`[CommentController] createComment called by userId: ${userId}, tenantId: ${tenantId}`);
+      if (!userId || !tenantId) {
+        console.warn('[CommentController] User or Tenant ID missing in createComment');
+        res.status(401).json({ error: 'User and Tenant ID required' });
         return;
       }
 
@@ -26,7 +27,7 @@ export class CommentController {
       }
 
       console.log(`[CommentController] Creating comment for projectId: ${projectId}, taskId: ${taskId}`);
-      const comment = await this.commentService.createComment(userId, { projectId, taskId, text });
+      const comment = await this.commentService.createComment(userId, tenantId, { projectId, taskId, text });
       console.log('[CommentController] Comment created:', comment);
       res.status(201).json(comment);
     } catch (error) {
@@ -42,10 +43,11 @@ export class CommentController {
   async getComments(req: Request, res: Response): Promise<void> {
     try {
       const userId = this.identityProvider.getUserId(req);
-      console.log(`[CommentController] getComments called by userId: ${userId}`);
-      if (!userId) {
-        console.warn('[CommentController] User ID missing in getComments');
-        res.status(401).json({ error: 'User ID required' });
+      const tenantId = this.identityProvider.getTenantId(req);
+      console.log(`[CommentController] getComments called by userId: ${userId}, tenantId: ${tenantId}`);
+      if (!userId || !tenantId) {
+        console.warn('[CommentController] User or Tenant ID missing in getComments');
+        res.status(401).json({ error: 'User and Tenant ID required' });
         return;
       }
 
@@ -57,7 +59,7 @@ export class CommentController {
       }
 
       console.log(`[CommentController] Fetching comments for projectId: ${projectId}, taskId: ${taskId}`);
-      const comments = await this.commentService.getComments(userId, projectId as string, taskId as string);
+      const comments = await this.commentService.getComments(userId, tenantId, projectId as string, taskId as string);
       console.log('[CommentController] Comments fetched:', comments);
       res.status(200).json(comments);
     } catch (error) {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted user ID from headers: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenant ID from headers: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -7,12 +7,12 @@ export class CommentService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async createComment(userId: string, request: CreateCommentRequest): Promise<Comment> {
-    console.log(`createComment called with userId=${userId}, projectId=${request.projectId}, taskId=${request.taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.CREATE);
-    console.log(`Permission check for CREATE comment: userId=${userId}, result=${hasPermission}`);
+  async createComment(userId: string, tenantId: string, request: CreateCommentRequest): Promise<Comment> {
+    console.log(`createComment called with userId=${userId}, tenantId=${tenantId}, projectId=${request.projectId}, taskId=${request.taskId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.COMMENT, Action.CREATE);
+    console.log(`Permission check for CREATE comment: userId=${userId}, tenantId=${tenantId}, result=${hasPermission}`);
     if (!hasPermission) {
-      console.error(`Access denied for userId=${userId} on create comment`);
+      console.error(`Access denied for userId=${userId}, tenantId=${tenantId} on create comment`);
       throw new Error('Access denied');
     }
 
@@ -30,12 +30,12 @@ export class CommentService {
     return comment;
   }
 
-  async getComments(userId: string, projectId: string, taskId: string): Promise<Comment[]> {
-    console.log(`getComments called with userId=${userId}, projectId=${projectId}, taskId=${taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.LIST);
-    console.log(`Permission check for LIST comment: userId=${userId}, result=${hasPermission}`);
+  async getComments(userId: string, tenantId: string, projectId: string, taskId: string): Promise<Comment[]> {
+    console.log(`getComments called with userId=${userId}, tenantId=${tenantId}, projectId=${projectId}, taskId=${taskId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.COMMENT, Action.LIST);
+    console.log(`Permission check for LIST comment: userId=${userId}, tenantId=${tenantId}, result=${hasPermission}`);
     if (!hasPermission) {
-      console.error(`Access denied for userId=${userId} on list comments`);
+      console.error(`Access denied for userId=${userId}, tenantId=${tenantId} on list comments`);
       throw new Error('Access denied');
     }
 


### PR DESCRIPTION
This PR contains the following modifications:

- AI (gemini/gemini-2.5-flash-lite):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /permissions/v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

Do not keep the old logic in permission service client.

```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)