### PR TITLE
Morph: Permission service migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,15 +34,16 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
     console.log(`[PermissionServiceClient] Checking permission:
-      subjectId=${subjectId}, domain=${domain}, action=${action}`);
+      subjectId=${subjectId}, tenantId=${tenantId}, domain=${domain}, action=${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/v2/permissions/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -26,7 +26,13 @@ export class CommentController {
       }
 
       console.log(`[CommentController] Creating comment for projectId: ${projectId}, taskId: ${taskId}`);
-      const comment = await this.commentService.createComment(userId, { projectId, taskId, text });
+      const tenantId = this.identityProvider.getTenantId(req);
+      if (!tenantId) {
+        console.warn('[CommentController] Tenant ID missing in createComment');
+        res.status(400).json({ error: 'Tenant ID required' });
+        return;
+      }
+      const comment = await this.commentService.createComment(userId, { projectId, taskId, text }, tenantId);
       console.log('[CommentController] Comment created:', comment);
       res.status(201).json(comment);
     } catch (error) {
@@ -57,7 +63,13 @@ export class CommentController {
       }
 
       console.log(`[CommentController] Fetching comments for projectId: ${projectId}, taskId: ${taskId}`);
-      const comments = await this.commentService.getComments(userId, projectId as string, taskId as string);
+      const tenantId = this.identityProvider.getTenantId(req);
+      if (!tenantId) {
+        console.warn('[CommentController] Tenant ID missing in getComments');
+        res.status(400).json({ error: 'Tenant ID required' });
+        return;
+      }
+      const comments = await this.commentService.getComments(userId, projectId as string, taskId as string, tenantId);
       console.log('[CommentController] Comments fetched:', comments);
       res.status(200).json(comments);
     } catch (error) {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted user ID from headers: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenant ID from headers: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -7,9 +7,9 @@ export class CommentService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async createComment(userId: string, request: CreateCommentRequest): Promise<Comment> {
-    console.log(`createComment called with userId=${userId}, projectId=${request.projectId}, taskId=${request.taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.CREATE);
+  async createComment(userId: string, request: CreateCommentRequest, tenantId: string): Promise<Comment> {
+    console.log(`createComment called with userId=${userId}, projectId=${request.projectId}, taskId=${request.taskId}, tenantId=${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.COMMENT, Action.CREATE);
     console.log(`Permission check for CREATE comment: userId=${userId}, result=${hasPermission}`);
     if (!hasPermission) {
       console.error(`Access denied for userId=${userId} on create comment`);
@@ -30,9 +30,9 @@ export class CommentService {
     return comment;
   }
 
-  async getComments(userId: string, projectId: string, taskId: string): Promise<Comment[]> {
-    console.log(`getComments called with userId=${userId}, projectId=${projectId}, taskId=${taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.LIST);
+  async getComments(userId: string, projectId: string, taskId: string, tenantId: string): Promise<Comment[]> {
+    console.log(`getComments called with userId=${userId}, projectId=${projectId}, taskId=${taskId}, tenantId=${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.COMMENT, Action.LIST);
     console.log(`Permission check for LIST comment: userId=${userId}, result=${hasPermission}`);
     if (!hasPermission) {
       console.error(`Access denied for userId=${userId} on list comments`);


### PR DESCRIPTION
This PR contains the following modifications:

- AI (deepseek/deepseek-chat):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)