### PR TITLE
Morph: Permission service migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,15 +34,16 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
     console.log(`[PermissionServiceClient] Checking permission:
-      subjectId=${subjectId}, domain=${domain}, action=${action}`);
+      subjectId=${subjectId}, tenantId=${tenantId}, domain=${domain}, action=${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -11,10 +11,16 @@ export class CommentController {
   async createComment(req: Request, res: Response): Promise<void> {
     try {
       const userId = this.identityProvider.getUserId(req);
-      console.log(`[CommentController] createComment called by userId: ${userId}`);
+      const tenantId = this.identityProvider.getTenantId(req);
+      console.log(`[CommentController] createComment called by userId: ${userId}, tenantId: ${tenantId}`);
       if (!userId) {
         console.warn('[CommentController] User ID missing in createComment');
         res.status(401).json({ error: 'User ID required' });
+        return;
+      }
+      if (!tenantId) {
+        console.warn('[CommentController] Tenant ID missing in createComment');
+        res.status(401).json({ error: 'Tenant ID required' });
         return;
       }
 
@@ -26,7 +32,7 @@ export class CommentController {
       }
 
       console.log(`[CommentController] Creating comment for projectId: ${projectId}, taskId: ${taskId}`);
-      const comment = await this.commentService.createComment(userId, { projectId, taskId, text });
+      const comment = await this.commentService.createComment(userId, tenantId, { projectId, taskId, text });
       console.log('[CommentController] Comment created:', comment);
       res.status(201).json(comment);
     } catch (error) {
@@ -42,10 +48,16 @@ export class CommentController {
   async getComments(req: Request, res: Response): Promise<void> {
     try {
       const userId = this.identityProvider.getUserId(req);
-      console.log(`[CommentController] getComments called by userId: ${userId}`);
+      const tenantId = this.identityProvider.getTenantId(req);
+      console.log(`[CommentController] getComments called by userId: ${userId}, tenantId: ${tenantId}`);
       if (!userId) {
         console.warn('[CommentController] User ID missing in getComments');
         res.status(401).json({ error: 'User ID required' });
+        return;
+      }
+      if (!tenantId) {
+        console.warn('[CommentController] Tenant ID missing in getComments');
+        res.status(401).json({ error: 'Tenant ID required' });
         return;
       }
 
@@ -57,7 +69,7 @@ export class CommentController {
       }
 
       console.log(`[CommentController] Fetching comments for projectId: ${projectId}, taskId: ${taskId}`);
-      const comments = await this.commentService.getComments(userId, projectId as string, taskId as string);
+      const comments = await this.commentService.getComments(userId, tenantId, projectId as string, taskId as string);
       console.log('[CommentController] Comments fetched:', comments);
       res.status(200).json(comments);
     } catch (error) {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted user ID from headers: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenant ID from headers: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -7,12 +7,12 @@ export class CommentService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async createComment(userId: string, request: CreateCommentRequest): Promise<Comment> {
-    console.log(`createComment called with userId=${userId}, projectId=${request.projectId}, taskId=${request.taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.CREATE);
-    console.log(`Permission check for CREATE comment: userId=${userId}, result=${hasPermission}`);
+  async createComment(userId: string, tenantId: string, request: CreateCommentRequest): Promise<Comment> {
+    console.log(`createComment called with userId=${userId}, tenantId=${tenantId}, projectId=${request.projectId}, taskId=${request.taskId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.COMMENT, Action.CREATE);
+    console.log(`Permission check for CREATE comment: userId=${userId}, tenantId=${tenantId}, result=${hasPermission}`);
     if (!hasPermission) {
-      console.error(`Access denied for userId=${userId} on create comment`);
+      console.error(`Access denied for userId=${userId}, tenantId=${tenantId} on create comment`);
       throw new Error('Access denied');
     }
 
@@ -30,12 +30,12 @@ export class CommentService {
     return comment;
   }
 
-  async getComments(userId: string, projectId: string, taskId: string): Promise<Comment[]> {
-    console.log(`getComments called with userId=${userId}, projectId=${projectId}, taskId=${taskId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.COMMENT, Action.LIST);
-    console.log(`Permission check for LIST comment: userId=${userId}, result=${hasPermission}`);
+  async getComments(userId: string, tenantId: string, projectId: string, taskId: string): Promise<Comment[]> {
+    console.log(`getComments called with userId=${userId}, tenantId=${tenantId}, projectId=${projectId}, taskId=${taskId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.COMMENT, Action.LIST);
+    console.log(`Permission check for LIST comment: userId=${userId}, tenantId=${tenantId}, result=${hasPermission}`);
     if (!hasPermission) {
-      console.error(`Access denied for userId=${userId} on list comments`);
+      console.error(`Access denied for userId=${userId}, tenantId=${tenantId} on list comments`);
       throw new Error('Access denied');
     }
 

--- a/tests/integration/comment.test.ts
+++ b/tests/integration/comment.test.ts
@@ -26,6 +26,7 @@ describe('Comment Integration Tests', () => {
   describe('POST /comments', () => {
     it('should create a comment successfully', async () => {
       const userId = 'user-123';
+      const tenantId = 'tenant-123';
       const commentData = {
         projectId: 'project-1',
         taskId: 'task-1',
@@ -33,9 +34,10 @@ describe('Comment Integration Tests', () => {
       };
 
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'COMMENT',
           action: 'CREATE'
         })
@@ -44,6 +46,7 @@ describe('Comment Integration Tests', () => {
       const response = await request(app)
         .post('/comments')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .send(commentData);
 
       expect(response.status).toBe(201);
@@ -66,14 +69,32 @@ describe('Comment Integration Tests', () => {
 
       const response = await request(app)
         .post('/comments')
+        .set('identity-tenant-id', 'tenant-123')
         .send(commentData);
 
       expect(response.status).toBe(401);
       expect(response.body).toEqual({ error: 'User ID required' });
     });
 
+    it('should return 401 when tenant ID is missing', async () => {
+      const commentData = {
+        projectId: 'project-1',
+        taskId: 'task-1',
+        text: 'This is a test comment'
+      };
+
+      const response = await request(app)
+        .post('/comments')
+        .set('identity-user-id', 'user-123')
+        .send(commentData);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Tenant ID required' });
+    });
+
     it('should return 403 when user lacks permission', async () => {
       const userId = 'user-123';
+      const tenantId = 'tenant-123';
       const commentData = {
         projectId: 'project-1',
         taskId: 'task-1',
@@ -81,9 +102,10 @@ describe('Comment Integration Tests', () => {
       };
 
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'COMMENT',
           action: 'CREATE'
         })
@@ -92,6 +114,7 @@ describe('Comment Integration Tests', () => {
       const response = await request(app)
         .post('/comments')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .send(commentData);
 
       expect(response.status).toBe(403);
@@ -102,14 +125,16 @@ describe('Comment Integration Tests', () => {
   describe('GET /comments', () => {
     it('should retrieve comments successfully', async () => {
       const userId = "user-" + randomUUID();
+      const tenantId = "tenant-" + randomUUID();
       const projectId = 'project-' + randomUUID();
       const taskId = 'task-1';
 
       // First create a comment
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'COMMENT',
           action: 'CREATE'
         })
@@ -118,6 +143,7 @@ describe('Comment Integration Tests', () => {
       await request(app)
         .post('/comments')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .send({
           projectId,
           taskId,
@@ -126,9 +152,10 @@ describe('Comment Integration Tests', () => {
 
       // Then retrieve comments
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'COMMENT',
           action: 'LIST'
         })
@@ -137,6 +164,7 @@ describe('Comment Integration Tests', () => {
       const response = await request(app)
         .get('/comments')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .query({ projectId, taskId });
 
       expect(response.status).toBe(200);
@@ -153,19 +181,32 @@ describe('Comment Integration Tests', () => {
     it('should return 401 when user ID is missing', async () => {
       const response = await request(app)
         .get('/comments')
+        .set('identity-tenant-id', 'tenant-123')
         .query({ projectId: 'project-1', taskId: 'task-1' });
 
       expect(response.status).toBe(401);
       expect(response.body).toEqual({ error: 'User ID required' });
     });
 
+    it('should return 401 when tenant ID is missing', async () => {
+      const response = await request(app)
+        .get('/comments')
+        .set('identity-user-id', 'user-123')
+        .query({ projectId: 'project-1', taskId: 'task-1' });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Tenant ID required' });
+    });
+
     it('should return 403 when user lacks permission', async () => {
       const userId = 'user-123';
+      const tenantId = 'tenant-123';
 
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'COMMENT',
           action: 'LIST'
         })
@@ -174,6 +215,7 @@ describe('Comment Integration Tests', () => {
       const response = await request(app)
         .get('/comments')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .query({ projectId: 'project-1', taskId: 'task-1' });
 
       expect(response.status).toBe(403);
@@ -182,13 +224,15 @@ describe('Comment Integration Tests', () => {
 
     it('should return empty array when no comments exist', async () => {
       const userId = 'user-456';
+      const tenantId = 'tenant-456';
       const projectId = 'project-2';
       const taskId = 'task-2';
 
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'COMMENT',
           action: 'LIST'
         })
@@ -197,6 +241,7 @@ describe('Comment Integration Tests', () => {
       const response = await request(app)
         .get('/comments')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .query({ projectId, taskId });
 
       expect(response.status).toBe(200);


### PR DESCRIPTION
This PR contains the following modifications:

- AI (deepseek/deepseek-chat):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)